### PR TITLE
fix: Expose cluster_id to allow recreation under a new unique name.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_elasticache_parameter_group" "default" {
 resource "aws_elasticache_cluster" "default" {
   count                      = local.enabled ? 1 : 0
   apply_immediately          = var.apply_immediately
-  cluster_id                 = module.this.id
+  cluster_id                 = var.cluster_id ? var.cluster_id : module.this.id
   engine                     = "memcached"
   engine_version             = var.engine_version
   node_type                  = var.instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "cluster_id" {
+  type        = string
+  default     = ""
+  description = "Group identifier. ElastiCache converts this name to lowercase. Changing this value will re-create the resource."
+}
+
 variable "vpc_id" {
   type        = string
   default     = ""


### PR DESCRIPTION
## what

Exposes the cluster id in the resource as an optional variable.

## why

When changing arguments in the module, a recreation needs to be triggered.  Providing a customizable user-provided, unique identifier allows for this.

## references

To be specified later.
